### PR TITLE
Remove unnecessary git commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,6 @@ jobs:
         run: |
           git fetch --no-tags --depth=1 origin ${{ github.base_ref }}
           git fetch --no-tags --depth=1 origin ${{ github.head_ref }}
-          # get the actual source for two branches
-          git checkout origin/${{ github.base_ref }}
-          git checkout origin/${{ github.head_ref }}
-          # get back to the merge commit
-          git checkout ${{ github.sha }}
 
       - name: All changed files 🗂
         run: git diff --name-only origin/${{ github.base_ref }} origin/${{ github.head_ref }}


### PR DESCRIPTION
Fixes https://github.com/bahmutov/changed-cy-tests/issues/4

Removes some unnecessary git command to simplify the code and potentially speed it up slightly.
The `git fetch` is enough to then be able to perform the `git diff`s we don't also need to checkout the branches that we fetch.